### PR TITLE
[kip] Disable search panel

### DIFF
--- a/json/kip.json
+++ b/json/kip.json
@@ -8,7 +8,7 @@
                 "searchSourceJSON": "{\"filter\":[],\"query\":{\"language\":\"lucene\",\"query\":{\"query_string\":{\"analyze_wildcard\":true,\"default_field\":\"*\",\"query\":\"*\"}}},\"highlightAll\":true,\"version\":true}"
             },
             "optionsJSON": "{\"darkTheme\":false,\"useMargins\":true}",
-            "panelsJSON": "[{\"panelIndex\":\"1\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":3,\"i\":\"1\"},\"id\":\"KIP_metrics\",\"title\":\"KIP Messages Metrics\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":0,\"y\":5,\"w\":6,\"h\":6,\"i\":\"3\"},\"id\":\"KIP_table\",\"title\":\"Details\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":2,\"i\":\"4\"},\"id\":\"KIP_ts\",\"title\":\"Messages\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"7\",\"gridData\":{\"x\":9,\"y\":0,\"w\":3,\"h\":3,\"i\":\"7\"},\"id\":\"KPI_status\",\"title\":\"Status\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"8\",\"gridData\":{\"x\":6,\"y\":0,\"w\":3,\"h\":3,\"i\":\"8\"},\"id\":\"KIP_org\",\"title\":\"Organizations\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"10\",\"gridData\":{\"x\":6,\"y\":3,\"w\":6,\"h\":4,\"i\":\"10\"},\"id\":\"kip_organizations_table\",\"title\":\"Organizations\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"11\",\"gridData\":{\"x\":0,\"y\":11,\"w\":12,\"h\":6,\"i\":\"11\"},\"id\":\"KIP_search\",\"type\":\"search\",\"version\":\"6.1.0-1\"},{\"title\":\"Projects\",\"panelIndex\":\"12\",\"gridData\":{\"x\":6,\"y\":7,\"w\":6,\"h\":4,\"i\":\"12\"},\"id\":\"c1f68160-ae04-11e8-8771-a349686d998a\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"}]",
+            "panelsJSON": "[{\"panelIndex\":\"1\",\"gridData\":{\"x\":0,\"y\":0,\"w\":6,\"h\":3,\"i\":\"1\"},\"id\":\"KIP_metrics\",\"title\":\"KIP Messages Metrics\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"3\",\"gridData\":{\"x\":0,\"y\":5,\"w\":6,\"h\":6,\"i\":\"3\"},\"id\":\"KIP_table\",\"title\":\"Details\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"4\",\"gridData\":{\"x\":0,\"y\":3,\"w\":6,\"h\":2,\"i\":\"4\"},\"id\":\"KIP_ts\",\"title\":\"Messages\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"7\",\"gridData\":{\"x\":9,\"y\":0,\"w\":3,\"h\":3,\"i\":\"7\"},\"id\":\"KPI_status\",\"title\":\"Status\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"8\",\"gridData\":{\"x\":6,\"y\":0,\"w\":3,\"h\":3,\"i\":\"8\"},\"id\":\"KIP_org\",\"title\":\"Organizations\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"panelIndex\":\"10\",\"gridData\":{\"x\":6,\"y\":3,\"w\":6,\"h\":4,\"i\":\"10\"},\"id\":\"kip_organizations_table\",\"title\":\"Organizations\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"},{\"title\":\"Projects\",\"panelIndex\":\"12\",\"gridData\":{\"x\":6,\"y\":7,\"w\":6,\"h\":4,\"i\":\"12\"},\"id\":\"c1f68160-ae04-11e8-8771-a349686d998a\",\"type\":\"visualization\",\"version\":\"6.1.0-1\"}]",
             "release_date": "2018-09-03T10:20:54.764818",
             "timeRestore": false,
             "title": "KIP",
@@ -16,12 +16,7 @@
             "version": 1
         }
     },
-    "searches": [
-        {
-            "id": "KIP_search",
-            "value": {}
-        }
-    ],
+    "searches": [],
     "visualizations": [
         {
             "id": "KIP_metrics",


### PR DESCRIPTION
The search panel is temporally disabled to speed up the migration. In the next iteration, the search panel will come back to its original place.