### PR TITLE
[doc][chaoss-gmd] Fix panel creation date

### DIFF
--- a/docs/_chaoss-gmd-cde/lines_of_code_changed.md
+++ b/docs/_chaoss-gmd-cde/lines_of_code_changed.md
@@ -2,7 +2,7 @@
 title: Lines of Code Changed
 description: panel focused on the number of lines of code changed.
 author: Miguel-Ángel Fernández Sánchez
-created_at: 2018-01-16
+created_at: 2019-01-16
 grimoirelab_version: 0.2.3
 layout: panel
 ---


### PR DESCRIPTION
After reviewing the documentation of "Lines of code changed" panel, I realized that the creation date had a typo, as I wrote 2018 and it should be **2019**.

I have updated the markdown accordingly.