### PR TITLE
Fix file name to use hypens instead of underscores

### DIFF
--- a/docs/_panels/gerrit-review-efficiency.md
+++ b/docs/_panels/gerrit-review-efficiency.md
@@ -2,7 +2,7 @@
 title: Gerrit Review Efficiency
 description: efficiency closing reviews in Gerrit.
 author: Bitergia
-screenshot: sigils/gerrit_review_efficiency.png
+screenshot: sigils/gerrit-review-efficiency.png
 created_at: 
 grimoirelab_version: 0.2.1
 layout: panel


### PR DESCRIPTION
This should fix the broken link on GitHub pages: https://chaoss.github.io/grimoirelab-sigils/panels/gerrit-review-efficiency/

Signed-off-by: Alberto Pérez García-Plaza <alpgarcia@bitergia.com>