### PR TITLE
Support newer versions of Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 "Bug Tracker" = "https://github.com/chaoss/grimoirelab-sigils/issues"
 
 [tool.poetry.dependencies]
-python = "3.7"
+python = "^3.7"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
When Poetry was added, only Python 3.7 support
was included. Change that to include higher versions.