### PR TITLE
Fix pyproject error tomlkit.exceptions.MixedArrayTypesError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 ]
 
 include = [
-    "panels/json/**/*.json",
+    { path = "panels/json/**/*.json" },
     { path = "AUTHORS", format = "sdist" },
     { path = "NEWS", format = "sdist" },
     { path = "README.md", format = "sdist" },


### PR DESCRIPTION
This PR updates an error raised by semverup when reading the pyproject.toml file. Now it keeps the same type on all elements of the `include`.
