### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: sigils-dist
           artifact-path: dist
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: sigils-dist
           artifact-path: dist

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Data model
 Each of the indexes are based on a previous definition. This
 is declared in CSV format with two columns: name and type.
 
-More information at the [Schema](https://github.com/chaoss/grimoirelab-elk/tree/master/schema) directory.
+More information at the [Schema](https://github.com/chaoss/grimoirelab-elk/tree/main/schema) directory.
 
 
 How this info was retrieved


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.